### PR TITLE
Refactor: move socket, replay, and send logic into custom hooks

### DIFF
--- a/src/hooks/useNetworkSocket.js
+++ b/src/hooks/useNetworkSocket.js
@@ -1,0 +1,87 @@
+import { useEffect, useState } from 'react';
+import io from 'socket.io-client';
+
+const socket = io('http://localhost:8000');
+
+export default function useNetworkSocket(activeSimId, setNodes, setEdges, setLoading) {
+  const [logs, setLogs] = useState({});
+  const [paths, setPaths] = useState({});
+  const [metricsBySim, setMetricsBySim] = useState({});
+  const [unreadCounts, setUnreadCounts] = useState({});
+  const [nodeSnapshots, setNodeSnapshots] = useState({});
+
+
+  useEffect(() => {
+    socket.on('networkUpdate', ({ message, nodes, edges, path, colorId, simulationId }) => {
+      if (!simulationId) return;
+
+      const tag = colorId != null ? `[${colorId}] ` : '';
+      const fullMessage = tag + message;
+
+      setLogs(prev => ({
+        ...prev,
+        [simulationId]: [...(prev[simulationId] || []), fullMessage],
+      }));
+
+      if (simulationId !== activeSimId) {
+        setUnreadCounts(prev => ({
+          ...prev,
+          [simulationId]: (prev[simulationId] || 0) + 1,
+        }));
+      }
+
+      if (Array.isArray(path)) {
+        setPaths(prev => ({ ...prev, [simulationId]: path }));
+      }
+
+      const safeNodes = Array.isArray(nodes) ? nodes.filter(n => n && n.id) : [];
+      const safeEdges = Array.isArray(edges) ? edges.filter(e => e && e.from && e.to) : [];
+
+      setNodes(safeNodes);
+      setEdges(safeEdges);
+      setLoading(false);
+
+      const retries = message?.includes('(retry') ? 1 : 0;
+      const drops = message?.includes('❌') ? 1 : 0;
+
+      setMetricsBySim(prev => ({
+        ...prev,
+        [simulationId]: {
+          pathLength: safeNodes.filter(n => n.color === '#4caf50' || n.color === '#f44336').length,
+          totalCost: safeEdges
+            .filter(e => e.color?.color === '#4caf50')
+            .reduce((sum, e) => sum + parseInt(e.label), 0),
+          retries: (prev[simulationId]?.retries || 0) + retries,
+          drops: (prev[simulationId]?.drops || 0) + drops,
+          nodeCount: safeNodes.length,
+          linkCount: safeEdges.length,
+        },
+      }));
+
+      setNodeSnapshots(prev => ({
+        ...prev,
+        [simulationId]: [...(prev[simulationId] || []), safeNodes],
+      }));
+    });
+
+    socket.on('connect_error', (error) => {
+      console.error('Connection Error:', error);
+      setLoading(false);
+    });
+
+    return () => {
+      socket.off('networkUpdate');
+      socket.off('connect_error');
+    };
+    // eslint-disable-next-line
+  }, [activeSimId]);
+
+  return {
+    socket,
+    logs,
+    paths,
+    metricsBySim,
+    unreadCounts,
+    nodeSnapshots,
+  };
+}

--- a/src/hooks/useReplaySimulation.js
+++ b/src/hooks/useReplaySimulation.js
@@ -1,0 +1,31 @@
+import { useState } from 'react';
+
+export default function useReplaySimulation(nodeSnapshots, setNodes) {
+  const [replayState, setReplayState] = useState({ simId: null, index: 0 });
+
+  const replaySimulation = (simId) => {
+    const snapshots = nodeSnapshots[simId];
+    if (!snapshots) return;
+
+    let i = 0;
+    setReplayState({ simId, index: 0 });
+
+    const interval = setInterval(() => {
+      if (i >= snapshots.length) return clearInterval(interval);
+      setNodes(snapshots[i]);
+
+      const activeNode = snapshots[i].find(n => n.color === '#f44336');
+      if (activeNode) {
+        const updated = snapshots[i].map(n =>
+          n.id === activeNode.id ? { ...n, color: '#ffeb3b' } : n
+        );
+        setNodes(updated);
+      }
+
+      setReplayState({ simId, index: i });
+      i++;
+    }, 800);
+  };
+
+  return { replayState, replaySimulation };
+}

--- a/src/hooks/useSendMessage.js
+++ b/src/hooks/useSendMessage.js
@@ -1,0 +1,54 @@
+export default function useSendMessage({
+    socket,
+    graph,
+    sourceNode,
+    destinationNode,
+    pathsInFlight,
+    setPathsInFlight,
+    setPacketColors,
+    COLORS,
+  }) {
+    const MAX_PARALLEL_MESSAGES = 2;
+  
+    const sendMessage = () => {
+      if (pathsInFlight.length >= MAX_PARALLEL_MESSAGES) {
+        alert('Please wait – packet limit reached.');
+        return;
+      }
+  
+      if (!sourceNode || !destinationNode) {
+        alert('Please select both source and destination.');
+        return;
+      }
+  
+      if (!graph[sourceNode] || !graph[destinationNode]) {
+        alert('Selected nodes do not exist in the graph.');
+        return;
+      }
+  
+      if (sourceNode === destinationNode) {
+        alert('Source and destination cannot be the same.');
+        return;
+      }
+  
+      const newId = pathsInFlight.length;
+      const assignedColor = COLORS[newId % COLORS.length];
+  
+      setPathsInFlight((prev) => [...prev, newId]);
+      setPacketColors((prev) => ({ ...prev, [newId]: assignedColor }));
+  
+      socket.emit('sendMessage', {
+        from: sourceNode,
+        to: destinationNode,
+        graph,
+        colorId: newId,
+      });
+  
+      setTimeout(() => {
+        setPathsInFlight((prev) => prev.filter((id) => id !== newId));
+      }, 6000);
+    };
+  
+    return sendMessage;
+  }
+  


### PR DESCRIPTION
**useNetworkSocket**

- Manages the socket connection (socket.io-client)
- Handles incoming networkUpdate and connect_error events
- Updates shared simulation state: logs, paths, metricsBySim, nodeSnapshots, and unreadCounts

**useSendMessage**
- Encapsulates message-sending logic
- Enforces max parallel packet limit (MAX_PARALLEL_MESSAGES)
- Handles packet color assignment and timeout cleanup

**useReplaySimulation**
- Manages node replay for a given simulation
- Handles replayState and step-by-step animation update