### PR TITLE
Add edge congestion color visualization based on link usage

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -129,7 +129,7 @@ function App() {
               dispatch={dispatch}
               onCloseTab={onCloseTab}
               replaySimulation={replaySimulation}
-              summary={summaries[activeSimId]} 
+              summary={activeSimId ? summaries[activeSimId] : null}
             />
 
             <GraphMetrics metrics={currentMetrics} activeSimId={activeSimId} />


### PR DESCRIPTION
This pull request adds dynamic edge coloring to the network visualization based on real-time link utilization. As messages traverse edges, usage counts are tracked and visually represented using a green → red color scale to indicate congestion levels.